### PR TITLE
Sanity bar should start at STARTING_SANITY

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -5,7 +5,7 @@ use crate::player::Player;
 use crate::{narrative, ui, SCREEN_HEIGHT, SCREEN_WIDTH};
 use bevy::prelude::*;
 
-const STARTING_SANITY: i32 = 75;
+pub const STARTING_SANITY: i32 = 75;
 
 #[derive(Default)]
 pub struct GameState {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -74,7 +74,7 @@ pub fn spawn_sanity_number(
     });
 }
 
-pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>, state: Res<GameState>) {
+pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn_bundle(UiCameraBundle::default());
     // The bundle holding the status bar i.e. the date
     commands
@@ -172,7 +172,7 @@ pub fn setup_ui(mut commands: Commands, asset_server: Res<AssetServer>, state: R
 
 
     // The white zone covering the bar. Don't ask.
-    let desired_width = mhb_bar_filling_width() * ( (100 - state.sanity) as f32 / 100.);
+    let desired_width = mhb_bar_filling_width() * ( (100 - STARTING_SANITY) as f32 / 100.);
     commands.spawn_bundle(SpriteBundle{
         transform: Transform {
             translation: [


### PR DESCRIPTION
This resolves the race condition around whether the game state or UI got initialised first.

Resolves #37 (still in principle need to discuss the underlying logic, but the technical issue discussed there is resolved)